### PR TITLE
 pseudo-selectors for variants

### DIFF
--- a/build.js
+++ b/build.js
@@ -92,8 +92,8 @@ const unsupportedProperties = new Set([
 ]);
 
 const isUtilitySupported = (utility, rule) => {
-	// Skip utilities with pseudo-selectors
-	if (utility.includes(':')) {
+	// Skip utilities with hover and focus pseudo-selectors
+	if (utility.match(/\:(hover|focus)/)) {
 		return false;
 	}
 


### PR DESCRIPTION
This PR modifies the isUtilitySupported method to only skip utilities that use the web based pseudo-selectors hover and focus, as opposed to all pseudo-selectors.

This change enables the use of pseudo-selectors as variants on selectors, and greater configuration options with tailwind.config.js.

For example, a config:

```

module.exports = {
  plugins: [
  	plugin(function({ addComponents }) {
       const colorSchemes = {
        '.drawerContent': {
        	backgroundColor: “transparent",
			    '&:light': {
			      backgroundColor: "#ffffff",
			      activeTintColor: "#333333",
			      activeBackgroundColor: "#cccccc",
			      inactiveTintColor: "#111111",
			      inactiveBackgroundColor: "transparent"
			    },
			    '&:dark': {
			      backgroundColor: "#000000",
			      activeTintColor: "#e91e63",
			      activeBackgroundColor: "#111111",
			      inactiveTintColor: "#f9f9f9",
			      inactiveBackgroundColor: "transparent"
			    },
			  }
      }
      addComponents(colorSchemes)
    })
  ]
}
```

And then use could use the ReactNative ColorScheme hook:
```
export default function useColorScheme(): NonNullable<ReactNative.ColorSchemeName> {
  return ReactNative.useColorScheme() as NonNullable<ReactNative.ColorSchemeName>;
}
```

To render the style for the component based on the current colorScheme:

```
export default function Navigation() {
  const colorScheme = useColorScheme();

  return (
    <NavigationContainer>
      <Drawer.Navigator
        drawerContentOptions={style(`drawerContent:${colorScheme}`)}
…
```